### PR TITLE
Bump the faraday version

### DIFF
--- a/svelte.gemspec
+++ b/svelte.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '~> 2.4'
 
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday', '>= 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.10'
   spec.add_dependency 'typhoeus', '~> 1.0'
 


### PR DESCRIPTION
We are trying to upgrade the `sentry-raven` and the `sentry-ruby` gem, which depends on faraday >= 1.0.
So we are here to upgrade the faraday dependency in this gem.